### PR TITLE
retain changes in keep alive edit mode on refresh

### DIFF
--- a/jsoneditor/jsoneditor.py
+++ b/jsoneditor/jsoneditor.py
@@ -213,6 +213,10 @@ class Server:
                 callback_data = json.loads(
                     environ["wsgi.input"].read(request_body_size).decode("utf-8")
                 )["data"]
+                # fix for edit mode with keep alive setting
+                # apply the recieved data to instance data
+                # without this a refresh doesn't reflect saved changes
+                self.data = callback_data
                 self.callback(callback_data)
                 self.send_response("200 OK", "text/plain", respond)
                 yield b""


### PR DESCRIPTION
When used in keep alive & edit mode (jsoneditor -n -k -e) changes saved from UI are saved to the origin source file.
But the changes are not applied to the instance 'data' variable, which is used to serve the view.
Without this fix on refresh of page and changes will not reflect though available in source file. (inconsistent state)